### PR TITLE
downgrade npm version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "repository": "forter/few",
   "engines": {
     "node": ">=4.0.0",
-    "npm": "^3.4.1"
+    "npm": "^2.14.2"
   },
   "license": "Apache 2.0",
   "devDependencies": {


### PR DESCRIPTION
node 4.0.0 came out with npm 2.14.2, so it makes sense to aline the numbers so users won't see npm warnings.